### PR TITLE
Fixes react query discovered react query issues

### DIFF
--- a/src/components/assignment/assignmentmanage.component.tsx
+++ b/src/components/assignment/assignmentmanage.component.tsx
@@ -65,17 +65,21 @@ const LectureTable = (props: ILectureTableProps) => {
  * @param props Props of the lecture file components
  */
 export const AssignmentManageComponent = () => {
-  const { data: lectures = [] } = useQuery<Lecture[]>({
+  const { data: lectures, isLoading: isLoadingOngoingLectures } = useQuery<Lecture[]>({
     queryKey: ['lectures'],
     queryFn: () => getAllLectures(false)
   });
 
-  const { data: completedLectures = [] } = useQuery<Lecture[]>({
+  const { data: completedLectures, isLoading: isLoadingCompletedLectures } = useQuery<Lecture[]>({
     queryKey: ['completedLectures'],
     queryFn: () => getAllLectures(true)
   });
   
   const [showComplete, setShowComplete] = useState(false);
+
+  if (isLoadingCompletedLectures || isLoadingOngoingLectures) {
+    return <div>Loading...</div>
+  }
 
 
   return (

--- a/src/components/coursemanage/coursemanage.component.tsx
+++ b/src/components/coursemanage/coursemanage.component.tsx
@@ -60,17 +60,21 @@ const LectureTable = (props: ILectureTableProps) => {
 };
 
 export const CourseManageComponent = () => {
-  const { data: lectures = [] } = useQuery<Lecture[]>({
+  const { data: lectures, isLoading: isLoadingOngoingLectures } = useQuery<Lecture[]>({
     queryKey: ['lectures'],
     queryFn: () => getAllLectures(false)
   });
 
-  const { data: completedLectures = [] } = useQuery<Lecture[]>({
+  const { data: completedLectures, isLoading: isLoadingCompletedLectures } = useQuery<Lecture[]>({
     queryKey: ['completedLectures'],
     queryFn: () => getAllLectures(true)
   });
   
   const [showComplete, setShowComplete] = useState(false);
+
+  if (isLoadingCompletedLectures || isLoadingOngoingLectures) {
+    return <div>Loading...</div>
+  }
 
   return (
     <Stack direction={'column'} sx={{ mt: 5, ml: 5, flex: 1 }}>

--- a/src/components/coursemanage/files/files.tsx
+++ b/src/components/coursemanage/files/files.tsx
@@ -176,19 +176,19 @@ export const Files = (props: IFilesProps) => {
         openBrowser(
           `${lectureBasePath}${lecture.code}/${selectedDir}/${assignment.id}`
         );
+        getRemoteStatus(
+          props.lecture,
+          props.assignment,
+          RepoType.SOURCE,
+          true
+        ).then(status => {
+          setRepoStatus(
+            status as 'up_to_date' | 'pull_needed' | 'push_needed' | 'divergent'
+          );
+        });
       },
       this
     );
-    getRemoteStatus(
-      props.lecture,
-      props.assignment,
-      RepoType.SOURCE,
-      true
-    ).then(status => {
-      setRepoStatus(
-        status as 'up_to_date' | 'pull_needed' | 'push_needed' | 'divergent'
-      );
-    });
   }, [props.assignment, props.lecture]);
 
   /**

--- a/src/components/coursemanage/lecture.tsx
+++ b/src/components/coursemanage/lecture.tsx
@@ -37,6 +37,7 @@ import { updateMenus } from '../../menu';
 import { extractIdsFromBreadcrumbs } from '../util/breadcrumbs';
 import { useQuery } from '@tanstack/react-query';
 import { AssignmentDetail } from '../../model/assignmentDetail';
+import { queryClient } from '../../widgets/assignmentmanage';
 
 interface IAssignmentTableProps {
   lecture: Lecture;
@@ -200,6 +201,9 @@ export const LectureComponent = () => {
       async (response) => {
         await updateMenus(true);
         setLecture(response);
+        // Invalidate query key "lectures" and "completedLectures", so that we trigger refetch on lectures table and correct lecture name is shown in the table!
+        queryClient.invalidateQueries({ queryKey: ['lectures'] });
+        queryClient.invalidateQueries({ queryKey: ['completedLectures'] });  
       },
       (error) => {
         enqueueSnackbar(error.message, {

--- a/src/components/coursemanage/lecture.tsx
+++ b/src/components/coursemanage/lecture.tsx
@@ -168,9 +168,27 @@ export const LectureComponent = () => {
     enabled: !!lecture 
   });
 
+  React.useEffect(() => {
+    if (assignments.length > 0) {
+      setAssignments(assignments);
+    }
+  }, [assignments]);
+
+
   const [lectureState, setLecture] = React.useState(lecture);
-  const [assignmentsState, setAssignments] = React.useState(assignments);
+  const [assignmentsState, setAssignments] = React.useState<Assignment[]>([]);
   const [isEditDialogOpen, setEditDialogOpen] = React.useState(false);
+
+
+  if (isLoadingLecture || isLoadingAssignments) {
+    return (
+      <div>
+        <Card>
+          <LinearProgress />
+        </Card>
+      </div>
+    );
+  }
 
   const handleOpenEditDialog = () => {
     setEditDialogOpen(true);
@@ -192,15 +210,7 @@ export const LectureComponent = () => {
   };
 
 
-  if (isLoadingLecture || isLoadingAssignments) {
-    return (
-      <div>
-        <Card>
-          <LinearProgress />
-        </Card>
-      </div>
-    );
-  }
+
 
   return (
     <Stack direction={'column'} sx={{ mt: 5, ml: 5, flex: 1 }}>

--- a/src/services/file.service.ts
+++ b/src/services/file.service.ts
@@ -46,7 +46,7 @@ export const getFiles = async (path: string): Promise<File[]> => {
   const model = new FileBrowserModel({
     auto: false,
     manager: GlobalObjects.docManager,
-    refreshInterval: -1
+    refreshInterval: 0
   });
 
   try {
@@ -130,7 +130,7 @@ export const makeDir = async (path: string, name: string) => {
   const model = new FileBrowserModel({
     auto: false,
     manager: GlobalObjects.docManager,
-    refreshInterval: -1
+    refreshInterval: 1000000
   });
   try {
     await model.cd(path);


### PR DESCRIPTION
While working on #47 following issues regarding react query were discovered and this Merge Request solves them:

- `refreshInterval` in `getFiles` function (`fileservice.ts`) couldn't be -1, because only values between 0 and some "max" are allowed, now its set to 100000ms which is sufficient for our use case (approx 16 minutes).
- `getRemoteStatus` of source repository was refreshed only when some change has happened and we navigated to some other page and than back to files (in `coursemanage` components), now it's automatically updated whenever some file is added/removed/updated.
- When a lecture is renamed, immediately show new lecture name (before we had to navigate between pages and come back to lecture page so that new lecture name is shown).
- To add to previous point, also the lecture name in lecture table (one from which a single lecture is accessed) wasn't updated immediately and the change of ongoing lecture to completed lecture or reverse wasn't capture immediately. Aolution to this was to invalidate the two query keys `lectures` and `completedLectures` to enforce a refetch of lectures table.