### PR TITLE
React Query Fix: Immediately show feedback to student after instructor generated it

### DIFF
--- a/src/components/assignment/assignment.tsx
+++ b/src/components/assignment/assignment.tsx
@@ -102,7 +102,7 @@ export const AssignmentComponent = () => {
   });
 
   const { data: submissions = [], refetch: refetchSubmissions } = useQuery<Submission[]>({
-    queryKey: ['submissions', lectureId, assignmentId],
+    queryKey: ['submissionsAssignmentStudent', lectureId, assignmentId],
     queryFn: () => getAllSubmissions(lectureId, assignmentId, 'none', false),
     enabled: !!lectureId && !!assignmentId,
   });
@@ -119,7 +119,6 @@ export const AssignmentComponent = () => {
 
 
   React.useEffect(() => {
-    console.log("PLEASE LOOK", files)
     if (lecture && assignment) {
       getAssignmentProperties(lecture.id, assignment.id).then(properties => {
         const gb = new GradeBook(properties);

--- a/src/components/coursemanage/grading/manual-grading.tsx
+++ b/src/components/coursemanage/grading/manual-grading.tsx
@@ -47,6 +47,7 @@ import { showDialog } from '../../util/dialog-provider';
 import InfoIcon from '@mui/icons-material/Info';
 import { GraderLoadingButton } from '../../util/loading-button';
 import { useQuery } from '@tanstack/react-query';
+import { queryClient } from '../../../widgets/assignmentmanage';
 
 const style = {
   position: 'absolute' as const,
@@ -206,6 +207,7 @@ export const ManualGrading = () => {
         enqueueSnackbar('Generating feedback for submission!', {
           variant: 'success'
         });
+        queryClient.invalidateQueries({ queryKey: ['submissionsAssignmentStudent']});
         reload();
       } catch (err) {
         console.error(err);

--- a/src/components/coursemanage/grading/table-toolbar.tsx
+++ b/src/components/coursemanage/grading/table-toolbar.tsx
@@ -34,6 +34,7 @@ import { Link } from 'react-router-dom';
 import { openBrowser } from '../overview/util';
 import SearchIcon from '@mui/icons-material/Search';
 import ClearIcon from '@mui/icons-material/Clear';
+import { queryClient } from '../../../widgets/assignmentmanage';
 
 export const autogradeSubmissionsDialog = async handleAgree => {
   showDialog(
@@ -186,6 +187,7 @@ export function EnhancedTableToolbar(props: EnhancedTableToolbarProps) {
         enqueueSnackbar(`Generating feedback for ${numSelected} submissions!`, {
           variant: 'success'
         });
+        queryClient.invalidateQueries({ queryKey: ['submissionsAssignmentStudent']});
       } catch (err) {
         console.error(err);
         enqueueSnackbar('Error Generating Feedback', {


### PR DESCRIPTION
- There was a problem with react query where feedback couldn't be properly loaded, because of undefined submission (meaning at the moment where we are trying to access submission, it's still not fully loaded) -> fixed
- When instructor generates feedback for a submission, a refetch on submissions shown to student is enforced, so they see it immediately without a need to reload the page.