### PR TITLE
Remove duplicated text

### DIFF
--- a/src/components/util/dialog.tsx
+++ b/src/components/util/dialog.tsx
@@ -203,7 +203,7 @@ export const EditLectureDialog = (props: IEditLectureProps) => {
                 {props.lecture.code === props.lecture.name && (
                   <Typography variant="body2" color="text.secondary">
                     The current name matches the lecture code. Consider updating
-                    updating it to something more descriptive.
+                    it to something more descriptive.
                   </Typography>
                 )}
               </Stack>


### PR DESCRIPTION
This PR removes the duplicated word `updating`, shown in the UI when renaming a lecture.