### PR TITLE
Fix: Enable manual grading of submissions for archived lectures

### DIFF
--- a/src/components/notebook/student-plugin/deadline-wrapper.tsx
+++ b/src/components/notebook/student-plugin/deadline-wrapper.tsx
@@ -23,7 +23,7 @@ export const DeadlineWrapper = (props: IDeadlineWrapperProps) => {
 
   React.useEffect(() => {
     if (lecture === null) {
-      getAllLectures().then(response => {
+      getAllLectures(false).then(response => {
         const l = response.find(
           l => l.code === props.notebookPaths[lectureSubPaths]
         );

--- a/src/services/lectures.service.ts
+++ b/src/services/lectures.service.ts
@@ -8,7 +8,7 @@ import { Lecture } from '../model/lecture';
 import { request, HTTPMethod } from './request.service';
 
 export function getAllLectures(
-  complete: boolean = false,
+  complete?: boolean,
   reload = false
 ): Promise<Lecture[]> {
   let url = 'api/lectures';


### PR DESCRIPTION
Effectively: enables switching to "Grading Mode" in a notebook submitted in a completed lecture.

There's an accompanying PR in grader-service: https://github.com/TU-Wien-dataLAB/grader-service/pull/322

Refs: https://github.com/TU-Wien-dataLAB/grader-service/issues/296