### PR TITLE
Fix: show only either active or complete lectures

### DIFF
--- a/src/services/lectures.service.ts
+++ b/src/services/lectures.service.ts
@@ -13,7 +13,7 @@ export function getAllLectures(
   reload = false
 ): Promise<Lecture[]> {
   let url = 'api/lectures';
-  if (complete) {
+  if (complete != null) {
     const searchParams = new URLSearchParams({
       complete: String(complete)
     });


### PR DESCRIPTION
This fix is related to the issue #91 in labextension and the PR in grader service: https://github.com/TU-Wien-dataLAB/grader-service/pull/335. 